### PR TITLE
Update for Linux 5.7

### DIFF
--- a/icenet.c
+++ b/icenet.c
@@ -143,8 +143,8 @@ static inline void clear_intmask(struct icenet_device *nic, uint32_t mask)
 static inline void post_send_frag(
 		struct icenet_device *nic, skb_frag_t *frag, int last)
 {
-	uintptr_t addr = page_to_phys(frag->page.p) + frag->page_offset;
-	uint64_t len = frag->size, partial = !last, packet;
+	uintptr_t addr = page_to_phys(frag->bv_page) + frag->bv_offset;
+	uint64_t len = frag->bv_len, partial = !last, packet;
 
 	packet = (partial << 63) | (len << 48) | (addr & 0xffffffffffffL);
 	iowrite64(packet, nic->iomem + ICENET_SEND_REQ);


### PR DESCRIPTION
I'm in the process of bumping Linux in FireMarshal which means updating the drivers. In 5.7, skb_frag_t changed from a custom struct to a struct bio_vec. See: https://lore.kernel.org/netdev/20190501144457.7942-1-willy@infradead.org/

The driver builds and loads into the kernel, I haven't tested it since we don't have an icenic model and I don't have a working firesim instance right now.