### PR TITLE
Make sure checksum enable is set before receive buffers allocated

### DIFF
--- a/icenet.c
+++ b/icenet.c
@@ -416,6 +416,11 @@ static int icenet_open(struct net_device *ndev)
 	struct icenet_device *nic = netdev_priv(ndev);
 	unsigned long flags;
 
+#ifdef CONFIG_ICENET_CHECKSUM
+	iowrite8(1, nic->iomem + ICENET_CSUM_ENABLE);
+	mb();
+#endif
+
 	napi_enable(&nic->napi);
 
 	alloc_recv(ndev);
@@ -424,9 +429,6 @@ static int icenet_open(struct net_device *ndev)
 
 	spin_lock_irqsave(&nic->rx_lock, flags);
 	set_intmask(nic, ICENET_INTMASK_RX);
-#ifdef CONFIG_ICENET_CHECKSUM
-	iowrite8(1, nic->iomem + ICENET_CSUM_ENABLE);
-#endif
 	spin_unlock_irqrestore(&nic->rx_lock, flags);
 
 	printk(KERN_DEBUG "IceNet: opened device\n");


### PR DESCRIPTION
This icenet PR changes checksum offload so that checksums don't get processed until a receive buffer is posted. This ensures there isn't an issue with packets arriving before the driver enables checksums. However, for this to work properly, the checksum enable register must be set before any receive buffers are posted to the NIC.

https://github.com/firesim/icenet/pull/26